### PR TITLE
update ceres to version 0.3.6

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -17,7 +17,7 @@ end
 -- setup ceres layout
 ceres.layout = {
   mapsDirectory = "maps/",
-  srcDirectory = "dist/",
+  srcDirectories = {"dist/"},
   libDirectory = "lib//",
   targetDirectory = "build/"
 }


### PR DESCRIPTION
The binary originates from here: https://github.com/ceres-wc3/ceres/releases/download/v0.3.6/ceres-w3-v0.3.6-x86_64-pc-windows-gnu.tar.gz